### PR TITLE
Fixed selection of longest and shortest selection for ISIN

### DIFF
--- a/lib/security_identifiers/isin.rb
+++ b/lib/security_identifiers/isin.rb
@@ -15,10 +15,10 @@ module SecurityIdentifiers
     end
 
     def check_digit
-      longest, shortest = if even_values.last == digits.last
-         [even_values, odd_values]
-      else
+      longest, shortest = if odd_values.length == even_values.length
         [odd_values, even_values]
+      else
+        [even_values, odd_values]
       end
 
       longest = longest.map { |i| i * 2 }

--- a/spec/isin_spec.rb
+++ b/spec/isin_spec.rb
@@ -42,8 +42,28 @@ describe ISIN do
     end
   end
 
+  context 'Valid alphanumeric ISIN ETF' do
+    let(:isin) { ISIN.new('IE00B3RBWM25') }
+
+    it 'calculates the check digit' do
+      expect(isin.check_digit).to eql(5)
+    end
+
+    it 'validates the check digit' do
+      expect(isin).to be_valid
+    end
+  end
+
   context 'Invalid check digit' do
     let(:isin) { ISIN.new('US0378331004') }
+
+    it 'validates the check digit' do
+      expect(isin).to_not be_valid
+    end
+  end
+
+  context 'Invalid check digit ETF' do
+    let(:isin) { ISIN.new('IE00B3RBWM24') }
 
     it 'validates the check digit' do
       expect(isin).to_not be_valid


### PR DESCRIPTION
I noticed that a valid ETF ISIN was not correctly identified as valid. I changed the way the longest and shortest value (odd and even) of the ISIN are selected to correctly calculate the check digit.
