### PR TITLE
Follow more closely the algorithm from the ISIN Organization.

### DIFF
--- a/spec/isin_spec.rb
+++ b/spec/isin_spec.rb
@@ -42,6 +42,18 @@ describe ISIN do
     end
   end
 
+  context 'Regression alphanumeric ISIN' do
+    let(:isin) { ISIN.new('CA26210W1005') }
+
+    it 'calculates the check digit' do
+      expect(isin.check_digit).to eql(5)
+    end
+
+    it 'validates the check digit' do
+      expect(isin).to be_valid
+    end
+  end
+
   context 'Valid alphanumeric ISIN ETF' do
     let(:isin) { ISIN.new('IE00B3RBWM25') }
 


### PR DESCRIPTION
The definition of even and odd digits for ISIN is slightly different than that for CUSIP, which was causing an incorrect check digit to be be generated under certain circumstances in an ROR application when there were alphabetics in the identifier.  The ISIN code now closely follows the algorithm specified by the ISIN organization.
